### PR TITLE
Implement abstract methods and add import to fix build errors

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
 
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -21,6 +22,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.contact.Accommodation;
 import seedu.address.model.contact.Address;
 import seedu.address.model.contact.Contact;
 import seedu.address.model.contact.Email;
@@ -132,6 +134,11 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
+        private boolean isHalal;
+        private LocalTime openingHours;
+        private LocalTime closingHours;
+        private Accommodation.AccommodationStar stars;
+
 
         public EditContactDescriptor() {}
 
@@ -145,6 +152,10 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setHalal(toCopy.isHalal);
+            setOpeningHours(toCopy.openingHours);
+            setClosingHours(toCopy.closingHours);
+            setStars(toCopy.stars);
         }
 
         /**
@@ -203,6 +214,39 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        public Optional<Boolean> isHalal() {
+            return Optional.of(this.isHalal);
+        }
+
+        public void setHalal(boolean isHalal) {
+            this.isHalal = isHalal;
+        }
+
+        public Optional<LocalTime> getOpeningHours() {
+            return Optional.ofNullable(openingHours);
+        }
+
+        public void setOpeningHours(LocalTime openingHours) {
+            this.openingHours = openingHours;
+        }
+
+        public Optional<LocalTime> getClosingHours() {
+            return Optional.ofNullable(closingHours);
+        }
+
+        public void setClosingHours(LocalTime closingHours) {
+            this.closingHours = closingHours;
+        }
+
+
+        public Optional<Accommodation.AccommodationStar> getStars() {
+            return Optional.ofNullable(stars);
+        }
+
+        public void setStars(Accommodation.AccommodationStar stars) {
+            this.stars = stars;
+        }
+
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -219,7 +263,11 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditContactDescriptor.phone)
                     && Objects.equals(email, otherEditContactDescriptor.email)
                     && Objects.equals(address, otherEditContactDescriptor.address)
-                    && Objects.equals(tags, otherEditContactDescriptor.tags);
+                    && Objects.equals(tags, otherEditContactDescriptor.tags)
+                    && Objects.equals(isHalal, otherEditContactDescriptor.isHalal)
+                    && Objects.equals(openingHours, otherEditContactDescriptor.openingHours)
+                    && Objects.equals(closingHours, otherEditContactDescriptor.closingHours)
+                    && Objects.equals(stars, otherEditContactDescriptor.stars);
         }
 
         @Override
@@ -230,6 +278,10 @@ public class EditCommand extends Command {
                     .add("email", email)
                     .add("address", address)
                     .add("tags", tags)
+                    .add("isHalal", isHalal)
+                    .add("openingHours", openingHours)
+                    .add("closingHours", closingHours)
+                    .add("stars", stars)
                     .toString();
         }
     }

--- a/src/main/java/seedu/address/model/contact/Accommodation.java
+++ b/src/main/java/seedu/address/model/contact/Accommodation.java
@@ -2,7 +2,9 @@ package seedu.address.model.contact;
 
 import java.util.Set;
 
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.tag.Tag;
+
 
 /**
  * Represents an Accommodation Contact in the address book.
@@ -41,5 +43,25 @@ public class Accommodation extends Contact {
 
     public AccommodationStar getStars() {
         return stars;
+    }
+
+    @Override
+    public String getType() {
+        return "Accommodation";
+    }
+
+    /**
+     * Returns a copy of the contact with its values edited.
+     */
+    @Override
+    public Contact edit(EditCommand.EditContactDescriptor editAccommodationDescriptor) {
+        Name updatedName = editAccommodationDescriptor.getName().orElse(getName());
+        Phone updatedPhone = editAccommodationDescriptor.getPhone().orElse(getPhone());
+        Email updatedEmail = editAccommodationDescriptor.getEmail().orElse(getEmail());
+        Address updatedAddress = editAccommodationDescriptor.getAddress().orElse(getAddress());
+        Set<Tag> updatedTags = editAccommodationDescriptor.getTags().orElse(getTags());
+        AccommodationStar updatedStars = editAccommodationDescriptor.getStars().orElse(getStars());
+
+        return new Accommodation(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedStars);
     }
 }

--- a/src/main/java/seedu/address/model/contact/Attraction.java
+++ b/src/main/java/seedu/address/model/contact/Attraction.java
@@ -3,7 +3,9 @@ package seedu.address.model.contact;
 import java.time.LocalTime;
 import java.util.Set;
 
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.tag.Tag;
+
 
 /**
  * Represents an Attraction Contact in the address book.
@@ -47,5 +49,27 @@ public class Attraction extends Contact {
      */
     public LocalTime[] getOperatingHours() {
         return new LocalTime[]{ this.openingHours, this.closingHours };
+    }
+
+    @Override
+    public String getType() {
+        return "Attraction";
+    }
+
+    /**
+     * Returns a copy of the contact with its values edited.
+     */
+    @Override
+    public Contact edit(EditCommand.EditContactDescriptor editAttractionDescriptor) {
+        Name updatedName = editAttractionDescriptor.getName().orElse(getName());
+        Phone updatedPhone = editAttractionDescriptor.getPhone().orElse(getPhone());
+        Email updatedEmail = editAttractionDescriptor.getEmail().orElse(getEmail());
+        Address updatedAddress = editAttractionDescriptor.getAddress().orElse(getAddress());
+        Set<Tag> updatedTags = editAttractionDescriptor.getTags().orElse(getTags());
+        LocalTime updatedOpeningHours = editAttractionDescriptor.getOpeningHours().orElse(getOpeningHours());
+        LocalTime updatedClosingHours = editAttractionDescriptor.getClosingHours().orElse(getClosingHours());
+
+        return new Attraction(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
+                updatedOpeningHours, updatedClosingHours);
     }
 }

--- a/src/main/java/seedu/address/model/contact/Fnb.java
+++ b/src/main/java/seedu/address/model/contact/Fnb.java
@@ -2,7 +2,9 @@ package seedu.address.model.contact;
 
 import java.util.Set;
 
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.tag.Tag;
+
 
 /**
  * Represents an Fnb Contact in the address book.
@@ -30,5 +32,24 @@ public class Fnb extends Contact {
 
     public boolean isHalal() {
         return isHalal;
+    }
+
+    @Override
+    public String getType() {
+        return "FNB";
+    }
+
+    /**
+     * Returns a copy of the contact with its values edited.
+     */
+    @Override
+    public Contact edit(EditCommand.EditContactDescriptor editFnbDescriptor) {
+        Name updatedName = editFnbDescriptor.getName().orElse(getName());
+        Phone updatedPhone = editFnbDescriptor.getPhone().orElse(getPhone());
+        Email updatedEmail = editFnbDescriptor.getEmail().orElse(getEmail());
+        Address updatedAddress = editFnbDescriptor.getAddress().orElse(getAddress());
+        Set<Tag> updatedTags = editFnbDescriptor.getTags().orElse(getTags());
+        Boolean updatedHalal = editFnbDescriptor.isHalal().orElse(isHalal());
+        return new Fnb(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedHalal);
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.MenuItem;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;

--- a/src/test/java/seedu/address/logic/commands/EditContactDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactDescriptorTest.java
@@ -65,7 +65,11 @@ public class EditContactDescriptorTest {
                 + editContactDescriptor.getPhone().orElse(null) + ", email="
                 + editContactDescriptor.getEmail().orElse(null) + ", address="
                 + editContactDescriptor.getAddress().orElse(null) + ", tags="
-                + editContactDescriptor.getTags().orElse(null) + "}";
+                + editContactDescriptor.getTags().orElse(null) + ", isHalal="
+                + editContactDescriptor.isHalal().orElse(null) + ", openingHours="
+                + editContactDescriptor.getOpeningHours().orElse(null) + ", closingHours="
+                + editContactDescriptor.getClosingHours().orElse(null) + ", stars="
+                + editContactDescriptor.getStars().orElse(null) + "}";
         assertEquals(expected, editContactDescriptor.toString());
     }
 }


### PR DESCRIPTION
Abstract methods in Contact getType and edit need to be implemented.

Let's add implementations for the methods in the children classes, as well as make changes accordingly in EditCommand, and EditContactDescriptorTest accordingly.

MenuItem symbol could not be resolved in MainWindow presumably due to the import accidentally being removed in a previous commit.

Let's add that import back in MainWindow.

Fixes #55 