### PR TITLE
Fix/PE Dry Run Bugs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -25,6 +25,13 @@ tweaked to accurately reflect current implementation. Namely in: `ContactClassDi
 `EditContactDescriptorClassDiagram.puml`, `FavouriteAddSequenceDiagram.puml`, `FavouriteViewSequenceDiagram.puml`
 * William: Usage of AI Tools (Open AI) as an extra layer of checks for bugs and typos.
 
+
+* Reiner: Usage of AI Tools (Claude) to assist in extending tests for tour assign, unassign, and view features, as well as their related test files. All AI-generated code was subsequently verified and tweaked to ensure correctness and consistency with the rest of the codebase. Namely in:
+`TourAssignCommandTest.java`, `TourUnassignCommandTest.java`, `TourViewCommandTest.java`, `TourAssignCommandParserTest.java`, `TourUnassignCommandParserTest.java`, `TourViewCommandParserTest.java`
+* Reiner: Usage of AI Tools (Claude) to assist in creating Plant UML diagrams which are subsequently verified and
+tweaked to accurately reflect current implementation. Namely in: `TourAssignSequenceDiagram.puml`, `TourUnassignSequenceDiagram.puml`, `TourViewSequenceDiagram.puml`
+* Reiner: Usage of AI Tools (Claude) as an extra layer of checks for bugs and typos.
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## **Setting up, getting started**

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -223,7 +223,7 @@ Bivago supports assigning and unassigning contacts to tour packages, as well as 
 
 <img src="images/TourUnassignSequenceDiagram.png" width="600" />
 
-`TourViewCommand` performs a similar operation to `FindCommand`, making use of `ContactIsInTourPredicate` to filter the contact list to only those assigned to the specified tour. The tour list is first reset to show all tours so that the index lookup is not affected by any prior filtering.
+`TourViewCommand` performs a similar operation to `FindCommand`, making use of `ContactIsInTourPredicate` to filter the contact list to only those assigned to the specified tour. The tour index is resolved against the currently displayed tour list, consistent with how other commands treat displayed indices.
 
 <img src="images/TourViewSequenceDiagram.png" width="600" />
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -249,6 +249,10 @@ Fields that are not applicable to the specified contact type will be rejected.
 For example, `h/true` will not apply to `person` contacts.
 </div>
 
+<div markdown="span" class="alert alert-info">:information_source: **Note:**
+A warning is shown if the new contact's phone, email, or address matches another existing contact. The contact is still added — the warning is informational only.
+</div>
+
 <details>
 <summary><b>Example:</b></summary>
 
@@ -290,6 +294,8 @@ Edits an existing contact in the contact list.
 * Existing values will be overwritten
 * When editing tags, existing tags are removed and replaced
 * To remove all tags, use `t/` with no value
+* The edit is rejected if the new values are identical to the existing contact (no actual change)
+* A warning is shown if the edited phone, email, or address matches another contact
 
 <details>
 <summary><b>Example:</b></summary>

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -1,10 +1,13 @@
 package seedu.address.logic;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.Model;
 import seedu.address.model.contact.Accommodation;
 import seedu.address.model.contact.Attraction;
 import seedu.address.model.contact.Contact;
@@ -84,6 +87,49 @@ public class Messages {
      */
     public static String format(Tour tour) {
         return tour.getTourName();
+    }
+
+    /**
+     * Returns a warning message listing contacts that share the same phone, email, or address
+     * as {@code target}, excluding {@code excluded} (for edits, pass the original contact; for
+     * adds, pass null). Returns an empty string if no overlaps are found.
+     */
+    public static String getFieldOverlapWarning(Model model, Contact target, Contact excluded) {
+        List<String> warnings = new ArrayList<>();
+        List<Contact> samePhone = new ArrayList<>();
+        List<Contact> sameEmail = new ArrayList<>();
+        List<Contact> sameAddress = new ArrayList<>();
+
+        for (Contact other : model.getAddressBook().getContactList()) {
+            if (other.equals(excluded) || other.equals(target)) {
+                continue;
+            }
+            if (other.getPhone().equals(target.getPhone())) {
+                samePhone.add(other);
+            }
+            if (other.getEmail().equals(target.getEmail())) {
+                sameEmail.add(other);
+            }
+            if (other.getAddress().equals(target.getAddress())) {
+                sameAddress.add(other);
+            }
+        }
+
+        if (!samePhone.isEmpty()) {
+            warnings.add("Warning: phone matches existing contact(s): " + joinNames(samePhone));
+        }
+        if (!sameEmail.isEmpty()) {
+            warnings.add("Warning: email matches existing contact(s): " + joinNames(sameEmail));
+        }
+        if (!sameAddress.isEmpty()) {
+            warnings.add("Warning: address matches existing contact(s): " + joinNames(sameAddress));
+        }
+
+        return warnings.isEmpty() ? "" : "\n" + String.join("\n", warnings);
+    }
+
+    private static String joinNames(List<Contact> contacts) {
+        return contacts.stream().map(c -> c.getName().toString()).collect(Collectors.joining(", "));
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/AddCommand.java
@@ -80,7 +80,8 @@ public class AddCommand extends Command {
 
         assert model.hasContact(contactToAdd) : "Contact should have been added";
         logger.fine(String.format("Added contact: %s", contactToAdd));
-        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(contactToAdd)));
+        String warning = Messages.getFieldOverlapWarning(model, contactToAdd, null);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(contactToAdd)) + warning);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -101,10 +101,11 @@ public class EditCommand extends Command {
 
         model.setContact(contactToEdit, editedContact);
         model.commitAddressBook();
-        assert contactToEdit != editedContact : "Original contact must have been edited";
         logger.fine(String.format("Edited contact from %s to %s", contactToEdit, editedContact));
 
-        return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact)));
+        String warning = Messages.getFieldOverlapWarning(model, editedContact, contactToEdit);
+        return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact))
+                + warning);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_OPENING_HOUR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STARS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CONTACTS;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -74,6 +74,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_CONTACT_SUCCESS = "Edited Contact: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_CONTACT = "This contact already exists in the address book.";
+    public static final String MESSAGE_NO_CHANGES = "The edited values are identical to the existing contact.";
 
     private static final Logger logger = LogsCenter.getLogger(EditCommand.class);
 
@@ -130,6 +131,11 @@ public class EditCommand extends Command {
         requireNonNull(editContactDescriptor);
 
         Contact editedContact = createEditedContact(contactToEdit, editContactDescriptor);
+
+        if (contactToEdit.equals(editedContact)) {
+            logger.info("No changes detected in EditCommand");
+            throw new CommandException(MESSAGE_NO_CHANGES);
+        }
 
         if (!contactToEdit.isSameContact(editedContact) && model.hasContact(editedContact)) {
             logger.info("Contact is already the same");

--- a/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/EditCommand.java
@@ -104,7 +104,6 @@ public class EditCommand extends Command {
         assert contactToEdit != editedContact : "Original contact must have been edited";
         logger.fine(String.format("Edited contact from %s to %s", contactToEdit, editedContact));
 
-        model.updateFilteredContactList(PREDICATE_SHOW_ALL_CONTACTS);
         return new CommandResult(String.format(MESSAGE_EDIT_CONTACT_SUCCESS, Messages.format(editedContact)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/tour/TourAssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tour/TourAssignCommand.java
@@ -52,8 +52,8 @@ public class TourAssignCommand extends Command {
         Contact contact = getContact(model.getFilteredContactList(), contactIndex);
         Tour tour = getTour(model.getFilteredTourList(), tourIndex);
         validateNotAssigned(contact, tour);
+        Contact updatedContact = contact.withTourAdded(tour);
         model.assignTour(contact, tour);
-        Contact updatedContact = getContact(model.getFilteredContactList(), contactIndex);
         model.commitAddressBook();
 
         logger.fine(String.format("Assigned tour to contact: %s", updatedContact));

--- a/src/main/java/seedu/address/logic/commands/tour/TourAssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tour/TourAssignCommand.java
@@ -53,10 +53,11 @@ public class TourAssignCommand extends Command {
         Tour tour = getTour(model.getFilteredTourList(), tourIndex);
         validateNotAssigned(contact, tour);
         model.assignTour(contact, tour);
+        Contact updatedContact = getContact(model.getFilteredContactList(), contactIndex);
         model.commitAddressBook();
 
-        logger.fine(String.format("Assigned tour to contact: %s", contact));
-        return new CommandResult(String.format(MESSAGE_ASSIGN_TOUR_SUCCESS, Messages.format(contact)));
+        logger.fine(String.format("Assigned tour to contact: %s", updatedContact));
+        return new CommandResult(String.format(MESSAGE_ASSIGN_TOUR_SUCCESS, Messages.format(updatedContact)));
     }
 
     private static Contact getContact(List<Contact> contactList, Index index) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/tour/TourUnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tour/TourUnassignCommand.java
@@ -53,8 +53,8 @@ public class TourUnassignCommand extends Command {
         Contact contact = getContact(model.getFilteredContactList(), contactIndex);
         Tour tour = getTour(model.getFilteredTourList(), tourIndex);
         validateIsAssigned(contact, tour);
+        Contact updatedContact = contact.withTourRemoved(tour);
         model.unassignTour(contact, tour);
-        Contact updatedContact = getContact(model.getFilteredContactList(), contactIndex);
         model.commitAddressBook();
         logger.fine(String.format("Unassigned tour from contact: %s", updatedContact));
         return new CommandResult(String.format(MESSAGE_UNASSIGN_TOUR_SUCCESS, Messages.format(updatedContact)));

--- a/src/main/java/seedu/address/logic/commands/tour/TourUnassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tour/TourUnassignCommand.java
@@ -54,9 +54,10 @@ public class TourUnassignCommand extends Command {
         Tour tour = getTour(model.getFilteredTourList(), tourIndex);
         validateIsAssigned(contact, tour);
         model.unassignTour(contact, tour);
+        Contact updatedContact = getContact(model.getFilteredContactList(), contactIndex);
         model.commitAddressBook();
-        logger.fine(String.format("Unassigned tour from contact: %s", contact));
-        return new CommandResult(String.format(MESSAGE_UNASSIGN_TOUR_SUCCESS, Messages.format(contact)));
+        logger.fine(String.format("Unassigned tour from contact: %s", updatedContact));
+        return new CommandResult(String.format(MESSAGE_UNASSIGN_TOUR_SUCCESS, Messages.format(updatedContact)));
     }
 
     private static Contact getContact(List<Contact> contactList, Index index) throws CommandException {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.Scene?>
 <?import javafx.stage.Stage?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Bivago" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="Bivago" minWidth="800" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/bivago_icon.png" />
   </icons>

--- a/src/test/java/seedu/address/logic/commands/contact/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/AddCommandIntegrationTest.java
@@ -33,9 +33,10 @@ public class AddCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addContact(validContact);
 
-        assertCommandSuccess(new AddCommand(validContact), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validContact)),
-                expectedModel);
+        String expectedMessage = String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validContact))
+                + Messages.getFieldOverlapWarning(expectedModel, validContact, null);
+
+        assertCommandSuccess(new AddCommand(validContact), model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/contact/EditCommandTest.java
@@ -81,16 +81,10 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    public void execute_noFieldSpecifiedUnfilteredList_failure() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_CONTACT, new EditContactDescriptor());
-        Contact editedContact = model.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_CONTACT_SUCCESS,
-                Messages.format(editedContact));
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_NO_CHANGES);
     }
 
     @Test
@@ -98,11 +92,11 @@ public class EditCommandTest {
         Contact contactToEdit = model.getFilteredContactList().get(INDEX_FNB_CONTACT.getZeroBased());
 
         FnbBuilder halalFnbBuilder = (FnbBuilder) ContactBuilder.fromContact(contactToEdit);
-        halalFnbBuilder.withHalalStatus("true");
+        halalFnbBuilder.withHalalStatus("false");
         Contact editedContact = halalFnbBuilder.build();
 
         EditContactDescriptor descriptor = new EditContactDescriptorBuilder()
-                .withHalalStatus("true")
+                .withHalalStatus("false")
                 .build();
         EditCommand editCommand = new EditCommand(INDEX_FNB_CONTACT, descriptor);
 
@@ -262,7 +256,8 @@ public class EditCommandTest {
                 Messages.format(editedContact));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setContact(model.getFilteredContactList().get(0), editedContact);
+        showContactAtIndex(expectedModel, INDEX_FIRST_CONTACT);
+        expectedModel.setContact(expectedModel.getFilteredContactList().get(0), editedContact);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/tour/TourAssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tour/TourAssignCommandTest.java
@@ -47,9 +47,10 @@ public class TourAssignCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.assignTour(contactToAssign, tourToAssign);
+        Contact updatedContact = expectedModel.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
 
         assertCommandSuccess(command, model,
-                String.format(TourAssignCommand.MESSAGE_ASSIGN_TOUR_SUCCESS, Messages.format(contactToAssign)),
+                String.format(TourAssignCommand.MESSAGE_ASSIGN_TOUR_SUCCESS, Messages.format(updatedContact)),
                 expectedModel);
     }
 

--- a/src/test/java/seedu/address/logic/commands/tour/TourUnassignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/tour/TourUnassignCommandTest.java
@@ -48,9 +48,10 @@ public class TourUnassignCommandTest {
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setContact(contactToUnassign, contactToUnassign.withTourRemoved(tourToUnassign));
+        Contact updatedContact = expectedModel.getFilteredContactList().get(INDEX_FIRST_CONTACT.getZeroBased());
 
         assertCommandSuccess(command, model,
-                String.format(TourUnassignCommand.MESSAGE_UNASSIGN_TOUR_SUCCESS, Messages.format(contactToUnassign)),
+                String.format(TourUnassignCommand.MESSAGE_UNASSIGN_TOUR_SUCCESS, Messages.format(updatedContact)),
                 expectedModel);
     }
 


### PR DESCRIPTION
* Fixes #238, Success message for tour-assign and assign now correctly reflects the tour. 
* Fixes #210, Add validation checks for edit commands that do no changes.
* Fixes #227, Removed filter reset for edit command.
* Fixes #180, Placed minimum UI size 
* Fixes #202, #208, Give warning for similar fields